### PR TITLE
fix: S3Config & CreatePetApi

### DIFF
--- a/src/main/java/cmf/commitField/domain/pet/controller/PetController.java
+++ b/src/main/java/cmf/commitField/domain/pet/controller/PetController.java
@@ -3,7 +3,9 @@ package cmf.commitField.domain.pet.controller;
 import cmf.commitField.domain.pet.entity.Pet;
 import cmf.commitField.domain.pet.service.PetService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -15,9 +17,12 @@ public class PetController {
     private final PetService petService;
 
     // 새로운 펫 추가
-    @PostMapping
-    public Pet createPet(@RequestParam String name, @RequestParam String imageUrl) {
-        return petService.createPet(name, imageUrl);
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public Pet createPet(
+            @RequestParam String name,
+            @RequestPart(value = "imageFile") MultipartFile imageFile
+    ) throws Exception {
+        return petService.createPet(name, imageFile);
     }
 
     // 모든 펫 조회

--- a/src/main/java/cmf/commitField/domain/pet/service/PetService.java
+++ b/src/main/java/cmf/commitField/domain/pet/service/PetService.java
@@ -2,9 +2,12 @@ package cmf.commitField.domain.pet.service;
 
 import cmf.commitField.domain.pet.entity.Pet;
 import cmf.commitField.domain.pet.repository.PetRepository;
+import cmf.commitField.global.aws.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
@@ -13,9 +16,17 @@ import java.util.Optional;
 public class PetService {
 
     private final PetRepository petRepository;
+    private final S3Service s3Service;
 
     // 새로운 펫 생성
-    public Pet createPet(String name, String imageUrl) {
+    public Pet createPet(String name, MultipartFile imageFile) throws IOException {
+
+        // ✅ S3 업로드 로직 추가
+        String imageUrl = null;
+        if (imageFile != null && !imageFile.isEmpty()) {
+            imageUrl = s3Service.uploadFile(imageFile, "pet-images");
+        }
+
         Pet pet = new Pet(name, imageUrl);
         return petRepository.save(pet);
     }

--- a/src/main/java/cmf/commitField/global/aws/s3/S3Config.java
+++ b/src/main/java/cmf/commitField/global/aws/s3/S3Config.java
@@ -1,16 +1,29 @@
 package cmf.commitField.global.aws.s3;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
 @Configuration
 public class S3Config {
+
+    @Value("${aws.access-key-id}")
+    private String accessKeyId;
+
+    @Value("${aws.secret-access-key}")
+    private String secretAccessKey;
+
     @Bean
     public S3Client s3Client() {
         return S3Client.builder()
                 .region(Region.AP_NORTHEAST_2)
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKeyId, secretAccessKey)
+                ))
                 .build();
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

#71 

## 📝 요약(Summary)

S3에 접속하기 위한 S3Config 파일 수정.
S3Service의 uploadFile 함수 사용하여서 Pet등록 API 수정 -> 이미지 S3에 저장됨

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

application-secret.yml 파일 수정되었습니다! -> 디코 확인해주세요
DB에 직접 도커로 들어가서 S3 URL 클릭하면 한글깨져서 접속 안되는 현상? 같은게 있습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).